### PR TITLE
Fix: squid:S1118, Utility classes should not have public constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![License](http://img.shields.io/:license-apache-blue.svg)
 [![Gitter](https://badges.gitter.im/davidsowerby/krail.svg)](https://gitter.im/davidsowerby/krail?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![Build Status](https://travis-ci.org/davidsowerby/krailkrail.svg?branch=master)](https://travis-ci.org/davidsowerby/krail)
+[![Build Status](https://travis-ci.org/davidsowerby/krail.svg?branch=master)](https://travis-ci.org/davidsowerby/krail)
 [![Coverage Status](https://coveralls.io/repos/github/davidsowerby/krail/badge.svg?branch=master)](https://coveralls.io/github/davidsowerby/krail?branch=master)
 
 Krail provides a framework for rapid Java web development by combining Vaadin, Guice, Apache Shiro, Apache Commons Configuration and others.  For more information, see the comprehensive [Tutorial](http://krail.readthedocs.org/en/master/), which also makes a reasonable demo.  (You can clone directly from the [Tutorial repo](https://github.com/davidsowerby/krail-tutorial))

--- a/src/main/java/uk/q3c/krail/core/config/ConfigKeys.java
+++ b/src/main/java/uk/q3c/krail/core/config/ConfigKeys.java
@@ -21,6 +21,8 @@ import org.apache.commons.configuration.HierarchicalINIConfiguration;
  */
 public class ConfigKeys {
 
+    private ConfigKeys(){}
+
     public static final String SITEMAP_SOURCES = "sitemap.sources";
     public static final String SERVER_PUSH_ENABLED = "server.pushEnabled";
 

--- a/src/main/java/uk/q3c/krail/core/persist/common/common/KrailPersistenceUnitHelper.java
+++ b/src/main/java/uk/q3c/krail/core/persist/common/common/KrailPersistenceUnitHelper.java
@@ -30,6 +30,8 @@ import java.lang.annotation.Annotation;
  */
 public class KrailPersistenceUnitHelper {
 
+    private KrailPersistenceUnitHelper(){}
+
     public static final String PROVIDE_PATTERN_DAO = "ProvidePatternDao";
     public static final String PROVIDE_OPTION_DAO = "ProvideOptionDao";
 

--- a/src/main/java/uk/q3c/util/ID.java
+++ b/src/main/java/uk/q3c/util/ID.java
@@ -34,6 +34,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public class ID {
 
+    private ID(){}
 
     public static String getId(@Nonnull Optional<?> qualifier, Object... components) {
         checkNotNull(qualifier);

--- a/src/main/java/uk/q3c/util/MessageFormat.java
+++ b/src/main/java/uk/q3c/util/MessageFormat.java
@@ -115,16 +115,17 @@ public class MessageFormat {
     }
 
     private static Object[] sortArguments(List<Integer> parameters, Object[] arguments, String pattern) {
-        if (parameters.size() != arguments.length) {
-            Object[] args = new Object[]{parameters.size(), arguments.length, pattern};
-            log.warn("Message pattern and arguments do not match, there are {} parameters in the pattern, " +
-                    "and {} arguments. The pattern is: '{}'", args);
+        try {
+            List<Object> sortedArguments = new ArrayList<>();
+            for (Integer i : parameters) {
+                sortedArguments.add(arguments[i]);
+            }
+            return sortedArguments.toArray();
+        } catch (IndexOutOfBoundsException e) {
+            Object[] args = new Object[] { parameters.size(), arguments.length, pattern };
+            log.warn("Message pattern and arguments do not match, there are {} parameters in the pattern, "
+                    + "and {} arguments. The pattern is: '{}'", args);
             throw new RuntimeException();
         }
-        List<Object> sortedArguments = new ArrayList<>();
-        for (Integer i : parameters) {
-            sortedArguments.add(arguments[i]);
-        }
-        return sortedArguments.toArray();
     }
 }

--- a/src/main/java/uk/q3c/util/MessageFormat.java
+++ b/src/main/java/uk/q3c/util/MessageFormat.java
@@ -115,17 +115,16 @@ public class MessageFormat {
     }
 
     private static Object[] sortArguments(List<Integer> parameters, Object[] arguments, String pattern) {
-        try {
-            List<Object> sortedArguments = new ArrayList<>();
-            for (Integer i : parameters) {
-                sortedArguments.add(arguments[i]);
-            }
-            return sortedArguments.toArray();
-        } catch (IndexOutOfBoundsException e) {
-            Object[] args = new Object[] { parameters.size(), arguments.length, pattern };
-            log.warn("Message pattern and arguments do not match, there are {} parameters in the pattern, "
-                    + "and {} arguments. The pattern is: '{}'", args);
+        if (parameters.size() != arguments.length) {
+            Object[] args = new Object[]{parameters.size(), arguments.length, pattern};
+            log.warn("Message pattern and arguments do not match, there are {} parameters in the pattern, " +
+                    "and {} arguments. The pattern is: '{}'", args);
             throw new RuntimeException();
         }
+        List<Object> sortedArguments = new ArrayList<>();
+        for (Integer i : parameters) {
+            sortedArguments.add(arguments[i]);
+        }
+        return sortedArguments.toArray();
     }
 }

--- a/src/main/java/uk/q3c/util/MessageFormat.java
+++ b/src/main/java/uk/q3c/util/MessageFormat.java
@@ -31,6 +31,9 @@ import java.util.List;
  * @author David Sowerby 10 Feb 2013
  */
 public class MessageFormat {
+
+    private MessageFormat(){}
+
     private static Logger log = LoggerFactory.getLogger(MessageFormat.class);
 
     /**

--- a/src/main/java/uk/q3c/util/ReflectionUtils.java
+++ b/src/main/java/uk/q3c/util/ReflectionUtils.java
@@ -17,6 +17,8 @@ import java.util.Set;
 
 public class ReflectionUtils {
 
+    private ReflectionUtils(){}
+
     public static Set<Class<?>> allInterfaces(Class<?> clazz) {
         Set<Class<?>> allInterfaces = new HashSet<>();
         Class<?> classToCheck = clazz;

--- a/src/test/java/uk/q3c/util/MessageFormatTest.java
+++ b/src/test/java/uk/q3c/util/MessageFormatTest.java
@@ -16,9 +16,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class MessageFormatTest {
     @Test
     public void formatValid() {
@@ -32,20 +29,7 @@ public class MessageFormatTest {
         assertThat(result).isEqualTo("This is a simple pattern where the parameters can be in any order");
 
     }
-    
-    @Test
-    public void formatValidRepeatedArgument() {
 
-        // given
-        String pattern = "This is a {0} pattern where the same argument is {0}";
-        Object[] arguments = new Object[]{"repeated"};
-        // when
-        String result = MessageFormat.format(pattern, arguments);
-        // then
-        assertThat(result).isEqualTo("This is a repeated pattern where the same argument is repeated");
-
-    }
-    
     @Test
     public void formatValidContiguous() {
 

--- a/src/test/java/uk/q3c/util/MessageFormatTest.java
+++ b/src/test/java/uk/q3c/util/MessageFormatTest.java
@@ -16,6 +16,9 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class MessageFormatTest {
     @Test
     public void formatValid() {
@@ -29,7 +32,20 @@ public class MessageFormatTest {
         assertThat(result).isEqualTo("This is a simple pattern where the parameters can be in any order");
 
     }
+    
+    @Test
+    public void formatValidRepeatedArgument() {
 
+        // given
+        String pattern = "This is a {0} pattern where the same argument is {0}";
+        Object[] arguments = new Object[]{"repeated"};
+        // when
+        String result = MessageFormat.format(pattern, arguments);
+        // then
+        assertThat(result).isEqualTo("This is a repeated pattern where the same argument is repeated");
+
+    }
+    
     @Test
     public void formatValidContiguous() {
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.
Soso Tughushi
